### PR TITLE
Fix V739 warning from PVS-Studio Static Analyzer

### DIFF
--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -108,7 +108,7 @@ void read_communities(char* filename)
 {
   FILE* fd;
   int i, c;
-  char ch;
+  int ch;
 
   if (o.debug > 0) printf("Using community file %s\n", filename);
 
@@ -201,7 +201,7 @@ void read_hosts(char* filename)
 {
   FILE* fd;
   char buf[100];
-  char ch;
+  int ch;
   size_t c;
 
   if (strcmp(filename, "-") == 0) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
[V739](https://www.viva64.com/en/w/v739/) EOF should not be compared with a value of the 'char' type. The '(ch = fgetc(fd))' should be of the 'int' type.