### PR TITLE
fix bug that the last line of input file is ignored

### DIFF
--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -34,7 +34,7 @@
 #endif
 
 #define MAX_COMMUNITIES 16384
-#define MAX_HOSTS 16777215
+#define MAX_HOSTS 65535
 #define MAX_COMMUNITY_SIZE 32
 
 char* snmp_errors[] = {
@@ -200,7 +200,7 @@ OUT:
 void read_hosts(char* filename)
 {
   FILE* fd;
-  char buf[65535];
+  char buf[100];
   char ch;
   size_t c;
 
@@ -219,7 +219,7 @@ void read_hosts(char* filename)
   host_count = 0;
   c = 0; ch = 0;
 
-  while (1) {
+  do {
     ch = fgetc(fd);
     if (ch == '\n' || ch == ' ' || ch == '\t' || ch == EOF) {
       buf[c] = '\0';
@@ -231,17 +231,14 @@ void read_hosts(char* filename)
         c = 0;
       }
     }
-    else {
-      if (ch != '\r')
+    else if (ch != '\r') {
         buf[c++] = ch;
     }
     if (c > sizeof(buf) - 1) {
       printf("IP address too long\n");
       exit(1);
     }
-    if (ch == EOF)
-      break;
-  }
+  } while (ch != EOF);
 
   if (fd != stdin) fclose(fd);
 

--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -314,7 +314,7 @@ void init_options(int argc, char *argv[])
       printf("Malformed IP address: %s\n", argv[optind - 1]);
       exit(1);
     }
-    // host_count = 1;
+
     if (o.debug > 0) printf("Target ip read from command line: %s\n", argv[optind - 1]);
   }
   else {

--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -232,7 +232,7 @@ void read_hosts(char* filename)
       }
     }
     else if (ch != '\r') {
-        buf[c++] = ch;
+      buf[c++] = ch;
     }
     if (c > sizeof(buf) - 1) {
       printf("IP address too long\n");


### PR DESCRIPTION
Hello, I found a bug in this tool that when it runs with `-i inputfile` parameter, the last line of the inputfile is ignored (if the file is not end with an empty new line), so this patch's main purpose is to fix this.
On the other hand, there is a line of enforced `host_count = 1;` when parsing target host in the command line, which override host_count set in `add_host()`, this disables netmask style target in command line, which feels pointless, so I just comment it out to allow target with netmask in command line args.