### PR TITLE
Fix missing malloc nullptr check

### DIFF
--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -119,7 +119,15 @@ void read_communities(char* filename)
 
   const int max_c = MAX_COMMUNITY_SIZE - 1;
   for (i = 0; i < MAX_COMMUNITIES && !feof(fd); ++i) {
-    community[i] = (char*)malloc(MAX_COMMUNITY_SIZE);
+    char* ptr = (char*)malloc(MAX_COMMUNITY_SIZE);
+
+    if (!ptr) {
+        fprintf(stderr, "Failed to allocate memory for community string %d\n", i);
+        exit(-1);
+    }
+
+    community[i] = ptr;
+
     community[i][0] = '\0';
     for (c = 0; (ch = fgetc(fd)) != EOF && !isspace(ch); ++c) {
       if (c < max_c) {


### PR DESCRIPTION
This addresses the issue found with PVS-Studio and reported in PR https://github.com/trailofbits/onesixtyone/pull/12

The solution proposed in PR #12 would skip all community strings for which the allocation would fail (probably all of them after the first one that fails).

The `malloc` function is used in `read_communities` which is used in `init_options` only if the user specifies a community file.

It is probably better to exit the program and inform the user that the allocation failed instead, and this is, what the changes in this commit do.