### PR TITLE
Fix scanning /16 subnets.

### DIFF
--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -34,7 +34,7 @@
 #endif
 
 #define MAX_COMMUNITIES 16384
-#define MAX_HOSTS 65535
+#define MAX_HOSTS 65536
 #define MAX_COMMUNITY_SIZE 32
 
 char* snmp_errors[] = {


### PR DESCRIPTION
This patch allows scanning a /16. With MAX_HOSTS set to 65535, it aborts on a "malformed IP address" error when you try scan a /16. So we set it to 65536, and it works.

Ideally the limit would be made even bigger for scanning say, a /8, but thats for later discussion.