### PR TITLE
onesixtyone.c: fix community input file (-c option)

### DIFF
--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -143,9 +143,9 @@ void read_communities(char* filename)
   }
 
   if (c == 0 && ch == -1)
-	community_count = i - 1;
+    community_count = i - 1;
   else
-	community_count = i;
+    community_count = i;
 
   fclose(fd);
 }

--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -142,7 +142,11 @@ void read_communities(char* filename)
     printf("MAX_COMMUNITIES (%d) reached. Remaining communities will be skipped \n", i);
   }
 
-  community_count = i;
+  if (c == 0 && ch == -1)
+	community_count = i - 1;
+  else
+	community_count = i;
+
   fclose(fd);
 }
 


### PR DESCRIPTION
onesixtyone was accounting one more community than it should when the file was '\n' terminated. To solve it, we should see if it's last community read was 0 sized and EOF was reached.