### PR TITLE
packaging changes - version fix, make install, manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+CC ?= gcc
+DESTDIR ?= /
+prefix ?= /usr
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+datarootdir ?= $(prefix)/share
+datadir ?= $(datarootdir)
+mandir ?= $(datarootdir)/man
+man1dir ?= $(mandir)/man1
+
 onesixtyone: onesixtyone.c
 	$(CC) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) -o onesixtyone onesixtyone.c
 
@@ -6,5 +16,11 @@ solaris: onesixtyone.c
 
 clean:
 	rm -rf onesixtyone
+
+install:
+	install -D onesixtyone $(DESTDIR)$(bindir)/onesixtyone
+	install -D -m 0644 dict.txt $(DESTDIR)$(datadir)/onesixtyone/dict.txt
+	install -m 0644 -pD onesixtyone.1 $(DESTDIR)$(man1dir)/onesixtyone.1
+
 
 .PHONY: solaris clean

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ clean:
 	rm -rf onesixtyone
 
 install:
-	install -D onesixtyone $(DESTDIR)$(bindir)/onesixtyone
-	install -D -m 0644 dict.txt $(DESTDIR)$(datadir)/onesixtyone/dict.txt
-	install -m 0644 -pD onesixtyone.1 $(DESTDIR)$(man1dir)/onesixtyone.1
+	install -p -D onesixtyone $(DESTDIR)$(bindir)/onesixtyone
+	install -p -D -m 0644 dict.txt $(DESTDIR)$(datadir)/onesixtyone/dict.txt
+	install -p -m 0644 -D onesixtyone.1 $(DESTDIR)$(man1dir)/onesixtyone.1
 
 
 .PHONY: solaris clean

--- a/onesixtyone.1
+++ b/onesixtyone.1
@@ -1,0 +1,64 @@
+.TH ONESIXTYONE
+.SH NAME
+onesixtyone \- efficient SNMP scanner
+.SH SYNOPSIS
+onesixtyone [options] <host> <community>
+.SH DESCRIPTION
+onesixtyone is an SNMP scanner which utilizes a sweep technique to achieve very
+high performance. It can scan an entire class B network in under 13 minutes.
+It can be used to discover devices responding to well-known community names
+or to mount a dictionary attack against one or more SNMP devices.
+
+onesixtyone takes a different approach to SNMP scanning. It takes advantage
+of the fact that SNMP is a connectionless protocol and sends all SNMP requests
+as fast as it can. Then the scanner waits for responses to come back and logs
+them, in a fashion similar to Nmap ping sweeps. By default onesixtyone waits
+for 10 milliseconds between sending packets, which is adequate for 100Mbs
+switched networks. The user can adjust this value via the -w command line
+option. If set to 0, the scanner will send packets as fast as the kernel would
+accept them, which may lead to packet drop.
+.SH OPTIONS
+.HP
+.B \-c <communityfile>
+file with community names to try
+.TP
+.B \-i <inputfile>
+file with target hosts
+.TP
+.B \-o <outputfile>
+output log
+.TP
+.B \-d
+debug mode, use twice for more information
+.TP
+.B \-w n
+wait n milliseconds (1/1000 of a second) between sending packets (default 10)
+.TP
+.B \-q
+quiet mode, do not print log to stdout, use with \-l
+.PP
+examples: onesixtyone \-c dict.txt 192.168.4.1 public
+.IP
+ \&onesixtyone \-c dict.txt \-i hosts \-o my.log \-w 100
+.HP
+.B \-c <communityfile>
+file with community names to try
+.TP
+.B \-i <inputfile>
+file with target hosts
+.TP
+.B \-o <outputfile>
+output log
+.TP
+.B \-d
+debug mode, use twice for more information
+.TP
+.B \-w n
+wait n milliseconds (1/1000 of a second) between sending packets (default 10)
+.TP
+.B \-q
+quiet mode, do not print log to stdout, use with \-l
+.PP
+examples: onesixtyone \-c dict.txt 192.168.4.1 public
+.IP
+\&onesixtyone \-c dict.txt \-i hosts \-o my.log \-w 100

--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -1,4 +1,4 @@
-/*  onesixtyone version 0.3.3
+/*  onesixtyone version 0.3.4
     Copyright (C) 2002,2003  solareclipse@phreedom.org
 
     This program is free software; you can redistribute it and/or modify
@@ -83,7 +83,7 @@ struct {
 void usage()
 {
   int i;
-  printf("onesixtyone 0.3.3 [options] <host> <community>\n");
+  printf("onesixtyone 0.3.4 [options] <host> <community>\n");
   printf("  -c <communityfile> file with community names to try\n");
   printf("  -i <inputfile>     file with target hosts\n");
   printf("  -o <outputfile>    output log\n");


### PR DESCRIPTION
Hello, 
this PR contains touches I use for packaging onesixtyone for Fedora. I hope it will be usefull for other distributions as well.

version - there was accidentaly 0.3.3 remaining in the 0.3.4 release
manpage - adding man page based on the --help
make install - adding GNU compatible variables for the directory locations and its defaults so it might be override by the specific settings of the distribution when package is being rebuild.

Best regards
Michal Ambroz