### PR TITLE
Fix destination port changes unexpectedly during scan

### DIFF
--- a/onesixtyone.c
+++ b/onesixtyone.c
@@ -927,7 +927,6 @@ int main(int argc, char* argv[])
 
   /* remote address */
   remote_addr.sin_family = AF_INET;
-  remote_addr.sin_port = htons(o.port);
 
   if (!o.quiet) printf("Scanning %d hosts, %d communities\n", host_count, community_count);
 
@@ -938,6 +937,7 @@ int main(int argc, char* argv[])
 
     for (i = 0; i < host_count; i++) {
       remote_addr.sin_addr.s_addr = host[i].addr;
+      remote_addr.sin_port = htons(o.port);
       if (o.debug > 1) printf("Sending to ip %s\n", inet_ntoa(*(struct in_addr*)&remote_addr.sin_addr.s_addr));
 
       ret = sendto(sock, &sendbuf, sendbuf_size, 0, (struct sockaddr*)&remote_addr, sizeof(remote_addr));


### PR DESCRIPTION
There is a bug where whenever the scanner receives a reply from another port than the set destination SNMP port (161) all subsequently send probe packets will be send to this port.

This is because send and receive use the same sockaddr_in struct (remote_addr). Incoming replies from a rogue target device can alter the destination port in the next iteration and therefore make the scanner stop working correctly and send unsolicited packets.

I fixed this by setting the destination port before each send iteration together with the next destination address.